### PR TITLE
fix: fix app crash when bd is not active

### DIFF
--- a/src/components/page-counter.tsx
+++ b/src/components/page-counter.tsx
@@ -31,7 +31,7 @@ export default function ViewsCounter() {
       >
         <Eye className="h-4 w-4 text-custom_purple" />
         <span className="font-mono text-white">
-          {isLoading ? <CircularLoader /> : views.toLocaleString()}
+          {isLoading ? <CircularLoader /> : views?.toLocaleString() || "0"}
         </span>
         <span className="text-xs text-[#FF8B8B]">{t("views")}</span>
       </div>


### PR DESCRIPTION
This pull request makes a minor update to the `ViewsCounter` component to handle cases where the `views` value may be `null` or `undefined`. Now, if `views` is not available, the component will display "0" instead of nothing.

* Improved display logic in `ViewsCounter` to show "0" when `views` is missing or falsy, preventing blank output.