### PR TITLE
fix: fix navbar and remove cuidomisgastos page(not active)

### DIFF
--- a/src/components/nav/menu-nav.tsx
+++ b/src/components/nav/menu-nav.tsx
@@ -2,7 +2,7 @@
 import Link from "next/link";
 import { useTranslations } from "next-intl";
 export default function MenuNav() {
-  const t = useTranslations("header_mobile");
+  const t = useTranslations("header");
 
   const links = ["projects", "experience", "about", "contact"];
 

--- a/src/components/nav/navbar.tsx
+++ b/src/components/nav/navbar.tsx
@@ -11,6 +11,13 @@ export default function CustomNavbar() {
 
   const t = useTranslations("header");
 
+  const links = ["projects", "experience", "about", "contact"];
+
+  const header = links.map((key) => ({
+    name: t(`${key}.name`),
+    href: t(`${key}.href`),
+  }));
+
   const openMenu = () => {
     setIsNavVisible(!isNavVisible);
   };
@@ -18,31 +25,17 @@ export default function CustomNavbar() {
     <>
       <nav className="xl:flex justify-between mt-4 top-2 sticky backdrop-blur-[600px] rounded-full z-50 hidden">
         <div className="flex justify-between w-full p-4 mx-auto text-white">
-          <Link
-            href="/#projects"
-            className="hover:text-custom_purple hover:transition-colors hover:duration-300 hover:ease-in-out cursor-pointer"
-          >
-            {t("project")}
-          </Link>
-          <Link
-            href="/#experience"
-            className="hover:text-custom_purple hover:transition-colors hover:duration-300 hover:ease-in-out cursor-pointer"
-          >
-            {t("experience")}
-          </Link>
-          <Link
-            href="/#about-me"
-            className="hover:text-custom_purple hover:transition-colors hover:duration-300 hover:ease-in-out cursor-pointer"
-          >
-            {t("about")}
-          </Link>
-          <Link
-            href="mailto:marc.penar@outlook.cl"
-            target="_blank"
-            className="hover:text-custom_purple hover:transition-colors hover:duration-300 hover:ease-in-out cursor-pointer"
-          >
-            {t("contact")}
-          </Link>
+          {header.map((link, index) => {
+            return (
+              <Link
+                key={index}
+                href={link.href}
+                className="hover:text-custom_purple hover:transition-colors hover:duration-300 hover:ease-in-out cursor-pointer"
+              >
+                {link.name}
+              </Link>
+            );
+          })}
         </div>
       </nav>
       <div className="xl:hidden">

--- a/src/components/projects/projects.tsx
+++ b/src/components/projects/projects.tsx
@@ -10,7 +10,7 @@ import {
 
 export default function Projects() {
   const t = useTranslations("projects");
-  const keys = ["agendapuntosaludconsciente","cuidomisgastos","img_to_text", "computecnicos"] as const;
+  const keys = ["agendapuntosaludconsciente","img_to_text", "computecnicos"] as const;
 
   const techMapping = {
     ts: <TypeScriptSvg />,

--- a/src/messages/en.json
+++ b/src/messages/en.json
@@ -9,17 +9,11 @@
     "message": "The page you are looking for does not exist.",
     "fallback": "Go back to the home page"
   },
-  "header": {
-    "project": "Projects",
-    "experience": "Experience",
-    "about": "About Me",
-    "contact": "Contact Me"
-  },
   "defaultLocale": {
     "label": "Change Language",
     "locale": "{locale, select , en {EN} es {ES} other {Unknown}}"
   },
-  "header_mobile": {
+  "header": {
     "projects": {
       "name": "Projects",
       "href": "/en/#projects"

--- a/src/messages/es.json
+++ b/src/messages/es.json
@@ -9,17 +9,11 @@
     "message": "La página que buscas no existe.",
     "fallback": "Volver al inicio"
   },
-  "header": {
-    "project": "Proyectos",
-    "experience": "Experiencia",
-    "about": "Sobre mí",
-    "contact": "Contáctame"
-  },
   "defaultLocale": {
     "label": "Cambiar Idioma",
     "locale": "{locale, select , en {EN} es {ES} other {Desconocido}}"
   },
-  "header_mobile": {
+  "header": {
     "projects": {
       "name": "Proyectos",
       "href": "/es/#projects"


### PR DESCRIPTION
This pull request refactors the navigation system to use a more structured and maintainable approach for navigation links, and updates the i18n message files to support this change. Additionally, it removes an unused project from the projects listing.

Navigation improvements:

* Refactored the navigation bar in `navbar.tsx` to generate links dynamically from a `links` array, using translated names and hrefs from the new nested `header` messages, instead of hardcoding each link.
* Updated `menu-nav.tsx` to use the unified `header` translation namespace instead of the old `header_mobile`.

Internationalization updates:

* Replaced the flat structure of navigation labels in both `en.json` and `es.json` with a nested structure under `header`, providing `name` and `href` for each navigation link. This supports the new dynamic navigation system. [[1]](diffhunk://#diff-8a2b44aca2c0d795c5537b872cf5ea0a558605c608e56e90837e96ad257817f2L12-R16) [[2]](diffhunk://#diff-99cc93a222afec1e4483c9be0e517908447ba09d368025a5e3c4812a45c30417L12-R16)

Project listing update:

* Removed the `cuidomisgastos` project from the `keys` array in `projects.tsx`, so it no longer appears in the projects list.